### PR TITLE
Give flaky tests some more time to succeed

### DIFF
--- a/receiver/opencensusreceiver/octrace/observability_test.go
+++ b/receiver/opencensusreceiver/octrace/observability_test.go
@@ -191,12 +191,12 @@ func (tote *testOCTraceExporter) ExportSpan(sd *trace.SpanData) {
 // TODO: Determine how to do this deterministic.
 func flush(traceSvcDoneFn func()) {
 	// Give it enough time to process the streamed spans.
-	<-time.After(20 * time.Millisecond)
+	<-time.After(500 * time.Millisecond)
 
 	// End the gRPC service to complete the RPC trace so that we
 	// can examine the RPC trace as well.
 	traceSvcDoneFn()
 
 	// Give it some more time to complete the RPC trace and export.
-	<-time.After(20 * time.Millisecond)
+	<-time.After(500 * time.Millisecond)
 }


### PR DESCRIPTION
Some of the tests in observability_test.go fail randomly.
It appears to be timing instability. This increases the pauses
temporarily to see if tests succeed to confirm it is indeed
a timing issue.

We will need a proper fix for the tests by replacing pauses with
waits for the right condition.